### PR TITLE
Cambios para realizar la pull

### DIFF
--- a/examples/CANReceiver/CANReceiver.ino
+++ b/examples/CANReceiver/CANReceiver.ino
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Selección del hardware a utilizar
-#define HW_RTLS_V4_0_X
-// #define HW_RTLS_V4_1_X
+// #define HW_RTLS_V4_0_X
+#define HW_RTLS_V4_1_X
 
 #include <CAN.h>
 #include "boards.h"

--- a/examples/CANReceiverCallback/CANReceiverCallback.ino
+++ b/examples/CANReceiverCallback/CANReceiverCallback.ino
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Selección del hardware a utilizar
-#define HW_RTLS_V4_0_X
-// #define HW_RTLS_V4_1_X
+// #define HW_RTLS_V4_0_X
+#define HW_RTLS_V4_1_X
 
 #include <CAN.h>
 #include "boards.h"

--- a/examples/CANSender/CANSender.ino
+++ b/examples/CANSender/CANSender.ino
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Selección del hardware a utilizar
-#define HW_RTLS_V4_0_X
-// #define HW_RTLS_V4_1_X
+// #define HW_RTLS_V4_0_X
+#define HW_RTLS_V4_1_X
 
 #include <CAN.h>
 #include "boards.h"


### PR DESCRIPTION
The default pcb definition has been changed to be able to launch the pull, but the objective of the pull is to review the 3 examples completely to understand how the CAN works.

They are only examples, there are more functions to read or write, when we have to put this in prod we will see how we do it.
